### PR TITLE
Add model adapter for request/response data conversion

### DIFF
--- a/src/niquests/async_session.py
+++ b/src/niquests/async_session.py
@@ -12,6 +12,7 @@ from http.cookiejar import CookieJar
 from urllib.parse import urljoin, urlparse
 
 from .middlewares import AsyncMiddleware, Middleware
+from .model_adapter import ModelAdapter
 from .status_codes import codes
 
 if typing.TYPE_CHECKING:
@@ -132,6 +133,7 @@ class AsyncSession(Session):
         timeout: TimeoutType | None = None,
         middlewares: list[Middleware | AsyncMiddleware] | None = None,
         retry_strategy: typing.Iterable[float] | None = None,
+            model_adapter: ModelAdapter | None = None,
     ):
         if [disable_ipv4, disable_ipv6].count(True) == 2:
             raise RuntimeError("Cannot disable both IPv4 and IPv6")
@@ -224,6 +226,9 @@ class AsyncSession(Session):
         #: This defaults to requests.models.DEFAULT_REDIRECT_LIMIT, which is
         #: 30.
         self.max_redirects: int = DEFAULT_REDIRECT_LIMIT
+
+        # Model adapter used to convert request model and response data to/from model types.
+        self.model_adapter: ModelAdapter | None = model_adapter
 
         #: Trust environment settings for proxy configuration, default
         #: authentication and similar.

--- a/src/niquests/model_adapter.py
+++ b/src/niquests/model_adapter.py
@@ -1,0 +1,11 @@
+from typing import Protocol, TypeVar, Any
+
+T = TypeVar("T")
+
+
+class ModelAdapter(Protocol):
+    def from_data(self, data: Any, model_type: type[T]) -> T:
+        pass
+
+    def to_data(self, model: Any) -> bytes:
+        pass

--- a/src/niquests/sessions.py
+++ b/src/niquests/sessions.py
@@ -63,6 +63,7 @@ from .exceptions import (
 )
 from .hooks import HOOKS, default_hooks, dispatch_hook
 from .middlewares import Middleware
+from .model_adapter import ModelAdapter
 
 # formerly defined here, reexposed here for backward compatibility
 from .models import (  # noqa: F401
@@ -249,6 +250,7 @@ class Session:
         timeout: TimeoutType | None = None,
         middlewares: list[Middleware] | None = None,
         retry_strategy: typing.Iterable[float] | None = None,
+            model_adapter: ModelAdapter | None = None,
     ):
         """
         :param resolver: Specify a DNS resolver that should be used within this Session.
@@ -375,6 +377,9 @@ class Session:
         #: Automatically set a URL prefix to every emitted request.
         self.base_url: str | None = base_url
 
+        # Model adapter used to convert request model and response data to/from model types.
+        self.model_adapter: ModelAdapter | None = model_adapter
+
         #: A CookieJar containing all currently outstanding cookies set on this
         #: session. By default it is a
         #: :class:`RequestsCookieJar <requests.cookies.RequestsCookieJar>`, but
@@ -477,6 +482,8 @@ class Session:
             middlewares=self.middlewares
             + request.middlewares,  # Simply merge the middlewares of the request with the session middlewares.
             base_url=self.base_url,
+            model=request.model,
+            model_adapter=request.model_adapter or self.model_adapter
         )
         return p
 


### PR DESCRIPTION
Introduce `ModelAdapter` to facilitate serialization and deserialization of models in requests and responses. Added support for `model` and `model_adapter` in sessions, requests, and responses. This improves flexibility when working with custom request and response data types.