### PR TITLE
Refactor model handling in request preparation.

### DIFF
--- a/src/niquests/model_adapter.py
+++ b/src/niquests/model_adapter.py
@@ -1,4 +1,4 @@
-from typing import Protocol, TypeVar, Any
+from typing import Protocol, TypeVar, Any, Tuple
 
 T = TypeVar("T")
 
@@ -7,5 +7,10 @@ class ModelAdapter(Protocol):
     def from_data(self, data: Any, model_type: type[T]) -> T:
         pass
 
-    def to_data(self, model: Any) -> bytes:
+    def to_data(self, model: Any) -> Tuple[bytes, str]:
+        """
+        Converts a model to bytes and a content type.
+        :param model: The model to convert.
+        :return: A tuple of bytes and content type.
+        """
         pass

--- a/src/niquests/models.py
+++ b/src/niquests/models.py
@@ -355,16 +355,16 @@ class PreparedRequest:
         model_adapter: ModelAdapter | None = None,
     ) -> None:
         """Prepares the entire request with the given parameters."""
-
+        self.model_adapter = model_adapter
         self.prepare_method(method)
         self.prepare_url(url, params, base_url=base_url)
         self.prepare_headers(headers)
         self.prepare_cookies(cookies)
-        self.prepare_body(data, files, json)
+        self.prepare_body(data, files, json, model)
         self.prepare_auth(auth)
 
-        self.model = model
-        self.model_adapter = model_adapter
+
+
 
         # Note that prepare_auth must be last to enable authentication schemes
         # such as OAuth to work on a fully prepared request.
@@ -493,6 +493,7 @@ class PreparedRequest:
         data: BodyType | AsyncBodyType | None,
         files: MultiPartFilesType | MultiPartFilesAltType | None,
         json: typing.Any | None = None,
+        model: typing.Any | None = None,
     ) -> None:
         """Prepares the given HTTP body data."""
 
@@ -506,8 +507,8 @@ class PreparedRequest:
         content_type: str | None = None
         enforce_form_data = False
 
-        if self.model is not None and self.model_adapter is not None:
-            body = self.model_adapter.to_data(self.model)
+        if model is not None and self.model_adapter is not None:
+            body, content_type = self.model_adapter.to_data(self.model)
 
         if not data and json is not None:
             # urllib3 requires a bytes-like body. Python 2's json.dumps


### PR DESCRIPTION
Reorganize model and model_adapter usage to streamline the request preparation process by passing the `model` directly to the `prepare_body()` method. Update `ModelAdapter.to_data()` to return both serialized data and content type to improve flexibility and clarity.