### PR TITLE
Refactor model adapter call to include request context

### DIFF
--- a/src/niquests/models.py
+++ b/src/niquests/models.py
@@ -1564,7 +1564,7 @@ class Response:
 
 
     def model(self, model_type: type[T]) -> T:
-        return self.model_adapter.from_data(self.content, model_type)
+        return self.request.model_adapter.from_data(self.content, model_type)
 
     @property
     def links(self):


### PR DESCRIPTION
The `model` method now accesses the `model_adapter` through the `request` object. This ensures proper context is maintained when calling `from_data`.