### PR TITLE
Refactor request handling in session send methods.

### DIFF
--- a/src/niquests/async_session.py
+++ b/src/niquests/async_session.py
@@ -384,17 +384,17 @@ class AsyncSession(Session):
         raise InvalidSchema(f"No connection adapters were found for {url!r}{additional_hint}")
 
     async def send(self, request: PreparedRequest, **kwargs: typing.Any) -> Response | AsyncResponse:  # type: ignore[override]
-        prep = await async_dispatch_hook(
+        request = await async_dispatch_hook(
             "pre_request",
             request.hooks,  # type: ignore[arg-type]
             request,
         )
-        for m in prep.middlewares:
-            await m.pre_request(self, prep, request_kwargs=kwargs) if isinstance(m, AsyncMiddleware) else m.pre_request(
-                self, prep, kwargs
+        for m in request.middlewares:
+            await m.pre_request(self, request, request_kwargs=kwargs) if isinstance(m, AsyncMiddleware) else m.pre_request(
+                self, request, kwargs
             )
 
-        assert prep.url is not None
+        assert request.url is not None
         exceptions: list[Exception] = []
         for i in self._retry_strategy:
             try:

--- a/src/niquests/sessions.py
+++ b/src/niquests/sessions.py
@@ -1126,15 +1126,15 @@ class Session:
         )
 
     def send(self, request: PreparedRequest, **kwargs: typing.Any) -> Response:
-        prep = dispatch_hook(
+        request = dispatch_hook(
             "pre_request",
             request.hooks,  # type: ignore[arg-type]
             request,
         )
-        for m in prep.middlewares:
-            m.pre_request(self, prep, request_kwargs=kwargs)
+        for m in request.middlewares:
+            m.pre_request(self, request, request_kwargs=kwargs)
 
-        assert prep.url is not None
+        assert request.url is not None
 
         exceptions: list[Exception] = []
         for i in self._retry_strategy:


### PR DESCRIPTION
Standardize variable naming for consistency in handling `request` and update middleware processing logic accordingly. Adjust assertions to reflect updated variable names for clearer code semantics.