### PR TITLE
Remove unnecessary generic type parameter from AsyncResponse

### DIFF
--- a/src/niquests/models.py
+++ b/src/niquests/models.py
@@ -1657,7 +1657,7 @@ class Response(typing.Generic[T]):
             release_conn()
 
 
-class AsyncResponse(Response, typing.Generic[T]):
+class AsyncResponse(Response):
     raw: BaseAsyncHTTPResponse | None
     _resolve_redirect: typing.Callable[  # type: ignore[assignment]
         [Response, PreparedRequest], typing.Awaitable[PreparedRequest | None]


### PR DESCRIPTION
The generic type parameter `T` in `AsyncResponse` was unused and provided no value. This change simplifies the class definition and avoids potential confusion.