### PR TITLE
Fix model method to use request's model_adapter

### DIFF
--- a/src/niquests/models.py
+++ b/src/niquests/models.py
@@ -2012,7 +2012,7 @@ class AsyncResponse(Response):
             raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
 
     async def model(self, model_type: type[T]) -> T: # type: ignore[override]
-        return self.model_adapter.from_data(await self.content, model_type)
+        return self.request.model_adapter.from_data(await self.content, model_type)
 
     async def close(self) -> None:  # type: ignore[override]
         if self.lazy:


### PR DESCRIPTION
Adjusts the `model` method to ensure it uses the correct `model_adapter` from the `request` object. This resolves potential inconsistencies in data handling and ensures proper behavior.